### PR TITLE
Partial reorganization to avoid global state

### DIFF
--- a/Asap2/Asap2File.cs
+++ b/Asap2/Asap2File.cs
@@ -80,11 +80,6 @@ namespace Asap2
 
     public class PROJECT
     {
-        public PROJECT(string name, string LongIdentifier)
-        {
-            this.LongIdentifier = LongIdentifier;
-            this.name = name;
-        }
         public string comment;
         public string nameComment = "/* Name           */";
         public string name;
@@ -133,12 +128,6 @@ namespace Asap2
 
     public class HEADER
     {
-        public HEADER(string longIdentifier, string version, string project_no)
-        {
-            this.longIdentifier = longIdentifier;
-            this.version = version;
-            this.project_no = project_no;
-        }
         public string longIdentifier;
         public string version;
         public string project_no;
@@ -157,12 +146,6 @@ namespace Asap2
 
     public class MODULE
     {
-        public MODULE(string name, string LongIdentifier)
-        {
-            this.LongIdentifier = LongIdentifier;
-            this.name = name;
-        }
-
         public string nameComment = "/* Name           */";
         public string name;
         public string LongIdentifierComment = "/* LongIdentifier */";


### PR DESCRIPTION
Partial reorganization to avoid global state and let the tree be built by parser.

This will cause the top the stack in the end to contain the whole tree of nodes created during reduce and avoid the global state. Somewhat neater. But may be less understandable :)