### PR TITLE
fixing decimal regexp to detect scientific notation

### DIFF
--- a/Asap2/Asap2.Language.analyzer.lex
+++ b/Asap2/Asap2.Language.analyzer.lex
@@ -12,7 +12,7 @@
 
 Identifier              [A-Za-z_][A-Za-z0-9_\.\[\]]*
 Space                   [ \t\u000c]
-Decimal                 [\-+]?[0-9]*\.?[0-9]+([eE][\-+]?[0-9]+)?
+Decimal                 [\-+]?[0-9]*\.?[0-9]+([\.]?[eE][\-+]?[0-9]+)?
 HexNumber               0x[0-9A-Fa-f]+
 Eol                     (\r?\n)
 Alignment               ALIGNMENT_[A-Za-z0-9_]+


### PR DESCRIPTION
I recently had an issue parsing an A2L file which had a decimal notation like

```
2.44140625e-004
1.e-002
```

this change on the regexp makes the A2L be fully parsed correctly